### PR TITLE
Use Actions that does not require credentials

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -4,9 +4,14 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: grantmcconnaughey/lintly-flake8-github-action@v1.0
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          failIf: new
-          args: "--isolated --exclude=.cache,.venv,.svn,CVS,.bzr,.hg,.git,__pycache__,.tox --max-line-length=119 ."
+            python-version: '3.8'
+      - name: Install flake8
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8
+      - name: Lint with flake8
+        run: flake8 . --isolated --exclude=.cache,.venv,.svn,CVS,.bzr,.hg,.git,__pycache__,.tox --max-line-length=100


### PR DESCRIPTION
The GitHub Actions that we were planning on using used GitHub
credentials to make comments on Pull Requests. Unfortunately, using
credentials is disabled on Pull Requests made from a fork.

That's why were dropping down to a regular CI flake8 check that does not
create fancy comments.